### PR TITLE
岡本梓沙(あずにゃん)の自己紹介追加

### DIFF
--- a/components/Members.vue
+++ b/components/Members.vue
@@ -32,6 +32,11 @@ const members: TeamMember[] = [
     displayname: 'roa',
     bio: `Ph.D.student of Information Science. I'm looking forward to developing with you`
   },
+  {
+    id: 'azufb',
+    displayname: 'Azusa Okamoto',
+    bio: `Frontend Developer in Hyogo. I usually use TypeScript and React. I'm interested in PHP, Express and Docker. Glad to study with you all.`
+  },
 ]
 </script>
 


### PR DESCRIPTION
【対応内容】
・自己紹介を追加致しました。
→idはazufb、表示名はAzusa Okamotoです。自己紹介文も記載しております。