### PR TITLE
refactor member card component

### DIFF
--- a/components/MembersCard.vue
+++ b/components/MembersCard.vue
@@ -6,11 +6,14 @@ type Props = {
   member: TeamMember
 }
 const props = defineProps<Props>()
-const customCard:any = resolveComponent(`Card${pascalCase(props.member.id)}`)
 
+const CustomCardName = `Card${pascalCase(props.member.id)}`
+const CustomCardComponent = resolveComponent(CustomCardName)
+
+const exists = computed(() => CustomCardComponent !== CustomCardName)
 </script>
 
 <template>
-  <component :is="customCard" v-if="customCard.name" :member="props.member" :id="props.member.id"/>
+  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id"/>
   <CardDefault v-else :member="props.member" :id="props.member.id"/>
 </template>

--- a/modules/dynamic-component/nuxt.ts
+++ b/modules/dynamic-component/nuxt.ts
@@ -1,0 +1,14 @@
+import { defineNuxtModule } from '@nuxt/kit'
+import type { ComponentsDir } from '@nuxt/schema'
+
+// dynamic components loader
+export default defineNuxtModule({
+  defaults: {
+    dirs: [] as (string | ComponentsDir)[]
+  },
+  async setup(moduleOptions, nuxt) {
+    nuxt.hook('components:dirs', (dirs) => {
+      dirs.unshift(...moduleOptions.dirs)
+    })
+  },
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,8 +3,14 @@ import { defineNuxtConfig } from 'nuxt'
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   components: {
-    global: true,
-    dirs: ['~/components']
+    dirs: [
+      {
+        global: true,
+        path: '~/components/Card',
+        prefix: 'Card',
+      },
+      '~/components',
+    ],
   },
   modules: [
     '@nuxt/content',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,21 +1,21 @@
 import { defineNuxtConfig } from 'nuxt'
+import { fileURLToPath } from 'node:url'
 
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
-  components: {
-    dirs: [
-      {
-        global: true,
-        path: '~/components/Card',
-        prefix: 'Card',
-      },
-      '~/components',
-    ],
-  },
   modules: [
     '@nuxt/content',
     '@nuxtjs/tailwindcss',
     '@nuxtjs/color-mode',
+    ['./modules/dynamic-component/nuxt', {
+      dirs: [
+        {
+          path: fileURLToPath(new URL('./components/Card', import.meta.url)),
+          global: true,
+          prefix: 'Card',
+        },
+      ],
+    }],
   ],
   // https://color-mode.nuxtjs.org
   colorMode: {


### PR DESCRIPTION
とくに何かしらの機能を実装したわけではありません

次の3つ実施

1. CustomCardComponent の型を any を使わずに実装
2. `nuxt.config.ts` で global に `~/components` を呼ばなくてよいように修正
3. 2 相当を実施する module を作成し 2 を代替
