### PR TITLE
Replace v-html in MembersCard component with slot

### DIFF
--- a/components/Card/Default.vue
+++ b/components/Card/Default.vue
@@ -19,13 +19,13 @@ const props = defineProps<Props>()
         <img class="w-12 h-12 object-cover rounded-full" :src="`https://github.com/${props.member.id}.png`" alt="">
       </div>
       <div>
-        <div class="text-lg text-slate-800 font-bold" v-html="props.member.displayname"></div>
-        <div class="text-sm text-slate-500" v-html="props.member.id"></div>
+        <div class="text-lg text-slate-800 font-bold">{{props.member.displayname}}</div>
+        <div class="text-sm text-slate-500">{{props.member.id}}</div>
       </div>
     </div>
 
     <div class="mt-6">
-      <p class="text-sm text-slate-700 leading-6" v-html="props.member.bio"></p>
+      <p class="text-sm text-slate-700 leading-6">{{props.member.bio}}</p>
     </div>
 
   </a>

--- a/components/Card/RieOkiAgn.vue
+++ b/components/Card/RieOkiAgn.vue
@@ -19,13 +19,13 @@ const props = defineProps<Props>()
         <img class="w-12 h-12 object-cover rounded-full" :src="`https://github.com/${props.member.id}.png`" alt="">
       </div>
       <div>
-        <div class="text-lg text-slate-800 font-bold" v-html="props.member.displayname"></div>
-        <div class="text-sm text-slate-500" v-html="props.member.id"></div>
+        <div class="text-lg text-slate-800 font-bold">{{props.member.displayname}}</div>
+        <div class="text-sm text-slate-500">{{props.member.id}}</div>
       </div>
     </div>
 
     <div class="mt-6">
-      <p class="text-sm text-slate-700 leading-6" v-html="props.member.bio"></p>
+      <p class="text-sm text-slate-700 leading-6">{{props.member.bio}}</p>
     </div>
 
   </a>

--- a/components/Card/SudoRoa.vue
+++ b/components/Card/SudoRoa.vue
@@ -22,8 +22,8 @@ const props = defineProps<Props>()
 
     <div class="absolute top-0 left-0 w-full h-full pl-12 pr-24 flex justify-center items-center">
       <div>
-        <div class="text-lg text-right text-gray-800 font-bold" v-html="props.member.displayname"></div>
-        <p class="mt-1 text-sm text-right text-gray-700 leading-6" v-html="props.member.bio"></p>
+        <div class="text-lg text-right text-gray-800 font-bold">{{props.member.displayname}}</div>
+        <p class="mt-1 text-sm text-right text-gray-700 leading-6">{{props.member.bio}}</p>
       </div>
     </div>
 

--- a/components/Card/TenpeiPeso.vue
+++ b/components/Card/TenpeiPeso.vue
@@ -21,9 +21,9 @@ const props = defineProps<Props>()
             <img class="w-full drop-shadow-md" :src="`https://github.com/${props.member.id}.png`" alt="">
           </div>
           <div>
-            <div class="text-lg text-sky-900 font-bold" v-html="props.member.displayname"></div>
-            <div class="text-sm text-blue-300" v-html="props.member.id"></div>
-            <p class="mt-2 text-sm text-sky-900 leading-6" v-html="props.member.bio"></p>
+            <div class="text-lg text-sky-900 font-bold">{{props.member.displayname}}</div>
+            <div class="text-sm text-blue-300">{{props.member.id}}</div>
+            <p class="mt-2 text-sm text-sky-900 leading-6">{{props.member.bio}}</p>
           </div>
         </div>
       </div>

--- a/components/Card/WakoP.vue
+++ b/components/Card/WakoP.vue
@@ -19,13 +19,13 @@ const props = defineProps<Props>()
           <img class="w-12 h-12 object-cover rounded-full" :src="`https://github.com/${props.member.id}.png`" alt="">
         </div>
         <div>
-          <div class="text-lg text-slate-800 font-bold"><slot name="displayname"></slot></div>
-          <div class="text-sm text-slate-500"><slot name="id"></slot></div>
+          <div class="text-lg text-slate-800 font-bold">{{props.member.displayname}}</div>
+          <div class="text-sm text-slate-500">{{props.member.id}}</div>
         </div>
       </div>
 
       <div class="mt-6 i-understand-css-completely">
-        <p class="text-sm text-slate-700 leading-6"><slot name="bio"></slot></p>
+        <p class="text-sm text-slate-700 leading-6">{{props.member.bio}}</p>
       </div>
   </a>
 

--- a/components/Card/WakoP.vue
+++ b/components/Card/WakoP.vue
@@ -19,13 +19,13 @@ const props = defineProps<Props>()
           <img class="w-12 h-12 object-cover rounded-full" :src="`https://github.com/${props.member.id}.png`" alt="">
         </div>
         <div>
-          <div class="text-lg text-slate-800 font-bold" v-html="props.member.displayname"></div>
-          <div class="text-sm text-slate-500" v-html="props.member.id"></div>
+          <div class="text-lg text-slate-800 font-bold"><slot name="displayname"></slot></div>
+          <div class="text-sm text-slate-500"><slot name="id"></slot></div>
         </div>
       </div>
 
       <div class="mt-6 i-understand-css-completely">
-        <p class="text-sm text-slate-700 leading-6" v-html="props.member.bio"></p>
+        <p class="text-sm text-slate-700 leading-6"><slot name="bio"></slot></p>
       </div>
   </a>
 

--- a/components/MembersCard.vue
+++ b/components/MembersCard.vue
@@ -14,6 +14,6 @@ const exists = computed(() => CustomCardComponent !== CustomCardName)
 </script>
 
 <template>
-  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id"/>
-  <CardDefault v-else :member="props.member" :id="props.member.id"/>
+  <component :is="CustomCardComponent" v-if="exists" :member="props.member"/>
+  <CardDefault v-else :member="props.member"/>
 </template>

--- a/components/MembersCard.vue
+++ b/components/MembersCard.vue
@@ -14,6 +14,10 @@ const exists = computed(() => CustomCardComponent !== CustomCardName)
 </script>
 
 <template>
-  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id"/>
+  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id">
+    <template #displayname>{{member.displayname}}</template>
+    <template #id>{{member.id}}</template>
+    <template #bio>{{member.bio}}</template>
+  </component>
   <CardDefault v-else :member="props.member" :id="props.member.id"/>
 </template>

--- a/components/MembersCard.vue
+++ b/components/MembersCard.vue
@@ -14,10 +14,6 @@ const exists = computed(() => CustomCardComponent !== CustomCardName)
 </script>
 
 <template>
-  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id">
-    <template #displayname>{{member.displayname}}</template>
-    <template #id>{{member.id}}</template>
-    <template #bio>{{member.bio}}</template>
-  </component>
+  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id"/>
   <CardDefault v-else :member="props.member" :id="props.member.id"/>
 </template>


### PR DESCRIPTION
以下のissueの対応です。
https://github.com/commit-mate/commit-mate.net/issues/41

まずは認識合わせのためのミニマムな修正です。
そのため、MembersCard+私のカスタムカードのみの対応になります。

以下、質問です。
- `v-html`から`<slot/>`へ変更するモチベーションはXSSの回避ですか？
- 対応方法が合っている前提の質問になってしまいますが、以下のような{{}}ではなく`<slot/>`にするのはなぜですか？(どんなメリットがありますか？)
```html
<div class="w-full flex items-center space-x-4">
    <div>
        <img class="w-12 h-12 object-cover rounded-full" :src="`https://github.com/${props.member.id}.png`" alt="">
    </div>
    <div>
        <div class="text-lg text-slate-800 font-bold">{{member.displayname}}</div>
        <div class="text-sm text-slate-500">{{member.id}}</div>
    </div>
</div>
<div class="mt-6 i-understand-css-completely">
    <p class="text-sm text-slate-700 leading-6">{{member.bio}}</p>
</div>
```

- 今回の修正とは関係ありませんが、MembersCard.vueの以下のv-bind(`:id="props.member.id"`)は、`CustomCardComponent(or Default)`で使用してなさそうだったので削除しても問題なさそうかなって思ったのですがどうでしょうか？
```html
<template>
  <component :is="CustomCardComponent" v-if="exists" :member="props.member" :id="props.member.id">
</template>
```

Nuxt(Vue)完全に理解した()なので基本的なことから応用的なことまで
誰でもアドバイス頂けるとありがたいです！

